### PR TITLE
Add a function `deleteSubmap`

### DIFF
--- a/src/Data/Trie/Text.hs
+++ b/src/Data/Trie/Text.hs
@@ -51,6 +51,7 @@ module Data.Trie.Text
 
     -- * Single-value modification
     , alterBy, insert, adjust, delete
+    , deleteSubmap''
 
     -- * Combining tries
     , mergeBy, unionL, unionR
@@ -168,6 +169,12 @@ adjust f q = adjustBy (\_ _ -> f) q (impossible "adjust")
 delete :: Text -> Trie a -> Trie a
 {-# INLINE delete #-}
 delete q = alterBy (\_ _ _ -> Nothing) q (impossible "delete")
+
+deleteSubmap'' key trie =
+    foldr
+        (\k t -> delete k t)
+        trie
+        (map L.toStrict . keys $ submap key trie)
 
 {---------------------------------------------------------------
 -- Trie-combining functions

--- a/src/Data/Trie/Text.hs
+++ b/src/Data/Trie/Text.hs
@@ -51,6 +51,8 @@ module Data.Trie.Text
 
     -- * Single-value modification
     , alterBy, insert, adjust, delete
+    , deleteSubmap
+    , deleteSubmap'
     , deleteSubmap''
 
     -- * Combining tries

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,7 @@
 flags: {}
+resolver: lts-16.16
 packages:
 - .
 extra-deps:
-- bytestring-trie-0.2.5.0
-resolver: lts-13.15
+- bytestring-trie-0.2.5.0@sha256:9efa9c6f556314d28486be2470ff789419c5238ed2e354870623a3cbbd28fbe2,3349
+- microbench-0.1@sha256:f5c60aa2f40f9114aa0fb1fb2fe2f6cd8506d7ce3d1f0f46295d34651e523a2c,983

--- a/text-trie.cabal
+++ b/text-trie.cabal
@@ -73,9 +73,9 @@ Library
     -- The lower bounds are more restrictive than necessary.
     -- But then, we don't maintain any CI tests for older
     -- versions, so these are the lowest bounds we've verified.
-    Build-Depends: base       >= 4.5   && < 4.13
-                 , text       >= 1.2.3 && < 1.2.4
-                 , binary     >= 0.5.1 && < 0.8.7
+    Build-Depends: base       >= 4.5
+                 , text       >= 1.2.3
+                 , binary     >= 0.5.1
 
 ------------------------------------------------------------
 Test-Suite test-text-trie
@@ -90,16 +90,16 @@ Test-Suite test-text-trie
                   , FromListBench.Text.Encode
                   , TrieFile.Text
     build-depends: text-trie
-                 , base       >= 4.5   && < 4.13
-                 , bytestring >= 0.9.2 && < 0.11
-                 , text       >= 1.2.3 && < 1.2.4
-                 , binary     >= 0.5.1 && < 0.8.7
+                 , base       >= 4.5
+                 , bytestring >= 0.9.2
+                 , text       >= 1.2.3
+                 , binary     >= 0.5.1
                  , QuickCheck
                  , HUnit
                  , smallcheck
                  , microbench
-                 , bytestring-trie >= 0.2.5 && < 0.2.6
-                 , silently >= 1.2.5 && < 1.2.6
+                 , bytestring-trie >= 0.2.5
+                 , silently >= 1.2.5
 
 ------------------------------------------------------------
 ------------------------------------------------------- fin.


### PR DESCRIPTION
Could you add this new function?

I've been used `text-trie` for many use case, and I implement a function for myself like

    deleteSubmap' key trie =
        foldr
            (\k t -> delete k t)
            trie
            (map L.toStrict . keys $ submap key trie)

However, because it traverses every deleting target entries, this version is too slow.

Could you add my implementation in the `Data.Trie.Text.Internal`?

I'm not sure that the function's name and actual implementation is proper for your package.
If you care, please rename&change it.