### PR TITLE
Update text-trie.cabal

### DIFF
--- a/text-trie.cabal
+++ b/text-trie.cabal
@@ -73,9 +73,9 @@ Library
     -- The lower bounds are more restrictive than necessary.
     -- But then, we don't maintain any CI tests for older
     -- versions, so these are the lowest bounds we've verified.
-    Build-Depends: base       >= 4.5   && < 4.13
-                 , text       >= 1.2.3 && < 1.2.4
-                 , binary     >= 0.5.1 && < 0.8.7
+    Build-Depends: base       >= 4.5   && < 4.16
+                 , text       >= 1.2.3 && < 1.3
+                 , binary     >= 0.5.1 && < 0.11
 
 ------------------------------------------------------------
 Test-Suite test-text-trie
@@ -90,10 +90,10 @@ Test-Suite test-text-trie
                   , FromListBench.Text.Encode
                   , TrieFile.Text
     build-depends: text-trie
-                 , base       >= 4.5   && < 4.13
-                 , bytestring >= 0.9.2 && < 0.11
-                 , text       >= 1.2.3 && < 1.2.4
-                 , binary     >= 0.5.1 && < 0.8.7
+                 , base       >= 4.5   && < 4.16
+                 , bytestring >= 0.9.2 && < 0.12
+                 , text       >= 1.2.3 && < 1.3
+                 , binary     >= 0.5.1 && < 0.11
                  , QuickCheck
                  , HUnit
                  , smallcheck


### PR DESCRIPTION
Relax upper version bounds on base, binary, bytestring, text