### PR TITLE
Fix build with GHC 9.2 and 9.4

### DIFF
--- a/src/Data/Text/Internal/Word.hs
+++ b/src/Data/Text/Internal/Word.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wall -fwarn-tabs #-}
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns, CPP #-}
 
 ----------------------------------------------------------------
 --                                                  ~ 2019.04.11
@@ -20,9 +20,24 @@ import qualified Data.Text as T
 import qualified Data.Text.Internal as TI
 import qualified Data.Text.Unsafe as TU
 import qualified Data.Text.Array as TA
-import Data.Word (Word16)
 
+#if MIN_VERSION_text(2,0,0)
+
+import Data.Word (Word8)
+type TextElem = Word8
+
+dropElem :: Int -> Text -> Text
+dropElem = TU.dropWord8
+
+#else
+
+import Data.Word (Word16)
 type TextElem = Word16
+
+dropElem :: Int -> Text -> Text
+dropElem = TU.dropWord16
+
+#endif
 
 headElem :: Text -> TextElem
 {-# INLINE [0] headElem #-}
@@ -33,7 +48,7 @@ tailElem :: Text -> Maybe Text
 tailElem xs =
   if T.null xs
      then Nothing
-     else Just $ TU.dropWord16 1 xs
+     else Just $ dropElem 1 xs
 
 toListElem :: Text -> [TextElem]
 toListElem xs =

--- a/src/Data/Text/Internal/Word.hs
+++ b/src/Data/Text/Internal/Word.hs
@@ -13,7 +13,7 @@
 -- Methods for accessing `Text` in terms of its constituent `Word16`'s
 ----------------------------------------------------------------
 
-module Data.Text.Internal.Word16 where
+module Data.Text.Internal.Word where
 
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/src/Data/Text/Internal/Word.hs
+++ b/src/Data/Text/Internal/Word.hs
@@ -10,7 +10,7 @@
 -- Maintainer  :  lambdamichael@gmail.com
 -- Stability   :  experimental
 --
--- Methods for accessing `Text` in terms of its constituent `Word16`'s
+-- Methods for accessing `Text` in terms of its constituent words
 ----------------------------------------------------------------
 
 module Data.Text.Internal.Word where
@@ -22,7 +22,9 @@ import qualified Data.Text.Unsafe as TU
 import qualified Data.Text.Array as TA
 import Data.Word (Word16)
 
-head16 :: Text -> Word16
+type TextElem = Word16
+
+head16 :: Text -> TextElem
 {-# INLINE [0] head16 #-}
 head16 (TI.Text xs i0 _) = xs `TA.unsafeIndex` i0
 
@@ -33,13 +35,13 @@ tail16 xs =
      then Nothing
      else Just $ TU.dropWord16 1 xs
 
-toList16 :: Text -> [Word16]
+toList16 :: Text -> [TextElem]
 toList16 xs =
   case tail16 xs of
     Nothing -> []
     Just ys -> head16 xs : toList16 ys
 
--- | Length of `Text` in `Word16`'s
+-- | Length of `Text` in `TextElem`'s
 -- length16 xs == length (toList16 xs)
 length16 :: Text -> Int
 {-# INLINE [0] length16 #-}

--- a/src/Data/Text/Internal/Word.hs
+++ b/src/Data/Text/Internal/Word.hs
@@ -24,26 +24,26 @@ import Data.Word (Word16)
 
 type TextElem = Word16
 
-head16 :: Text -> TextElem
-{-# INLINE [0] head16 #-}
-head16 (TI.Text xs i0 _) = xs `TA.unsafeIndex` i0
+headElem :: Text -> TextElem
+{-# INLINE [0] headElem #-}
+headElem (TI.Text xs i0 _) = xs `TA.unsafeIndex` i0
 
-tail16 :: Text -> Maybe Text
-{-# INLINE [1] tail16 #-}
-tail16 xs =
+tailElem :: Text -> Maybe Text
+{-# INLINE [1] tailElem #-}
+tailElem xs =
   if T.null xs
      then Nothing
      else Just $ TU.dropWord16 1 xs
 
-toList16 :: Text -> [TextElem]
-toList16 xs =
-  case tail16 xs of
+toListElem :: Text -> [TextElem]
+toListElem xs =
+  case tailElem xs of
     Nothing -> []
-    Just ys -> head16 xs : toList16 ys
+    Just ys -> headElem xs : toListElem ys
 
 -- | Length of `Text` in `TextElem`'s
--- length16 xs == length (toList16 xs)
-length16 :: Text -> Int
-{-# INLINE [0] length16 #-}
-length16 (TI.Text _ off len) = len - off
+-- lengthElem xs == length (toListElem xs)
+lengthElem :: Text -> Int
+{-# INLINE [0] lengthElem #-}
+lengthElem (TI.Text _ off len) = len - off
 

--- a/src/Data/Trie/Text.hs
+++ b/src/Data/Trie/Text.hs
@@ -12,7 +12,7 @@
 --
 -- An efficient implementation of finite maps from strings to values.
 -- The implementation is based on /big-endian patricia trees/, like
--- "Data.IntMap". We first trie on the `Word16` elements of `T.Text`
+-- "Data.IntMap". We first trie on the underlying elements of `T.Text`
 -- and then trie on the big-endian bit representation of those
 -- elements. For further details, see
 --

--- a/src/Data/Trie/Text/BitTwiddle.hs
+++ b/src/Data/Trie/Text/BitTwiddle.hs
@@ -32,7 +32,10 @@ import Data.Text.Internal.Word (TextElem)
 
 import Data.Bits
 
-#if __GLASGOW_HASKELL__ >= 902
+#if MIN_VERSION_text(2,0,0)
+import GHC.Exts  (Int(..), uncheckedShiftRLWord8# )
+import GHC.Word (Word8(..))
+#elif __GLASGOW_HASKELL__ >= 902
 import GHC.Exts  (Int(..), uncheckedShiftRLWord16# )
 import GHC.Word (Word16(..))
 #elif __GLASGOW_HASKELL__ >= 503
@@ -55,7 +58,9 @@ type Mask    = KeyElem
 uncheckedShiftRL :: TextElem -> Int -> TextElem
 {-# INLINE [0] uncheckedShiftRL #-}
 -- GHC: use unboxing to get @uncheckedShiftRL@ inlined.
-#if __GLASGOW_HASKELL__ >= 902
+#if MIN_VERSION_text(2,0,0)
+uncheckedShiftRL (W8# x) (I# i) = W8# (uncheckedShiftRLWord8# x i)
+#elif __GLASGOW_HASKELL__ >= 902
 uncheckedShiftRL (W16# x) (I# i) = W16# (uncheckedShiftRLWord16# x i)
 #elif __GLASGOW_HASKELL__
 uncheckedShiftRL (W16# x) (I# i) = W16# (uncheckedShiftRL# x i)

--- a/src/Data/Trie/Text/BitTwiddle.hs
+++ b/src/Data/Trie/Text/BitTwiddle.hs
@@ -32,7 +32,10 @@ import Data.Trie.TextInternal (TextElem)
 
 import Data.Bits
 
-#if __GLASGOW_HASKELL__ >= 503
+#if __GLASGOW_HASKELL__ >= 902
+import GHC.Exts  (Int(..), uncheckedShiftRLWord16# )
+import GHC.Word (Word16(..))
+#elif __GLASGOW_HASKELL__ >= 503
 import GHC.Exts  (Int(..), uncheckedShiftRL# )
 import GHC.Word (Word16(..))
 #elif __GLASGOW_HASKELL__
@@ -51,8 +54,10 @@ type Mask    = KeyElem
 
 uncheckedShiftRL :: Word16 -> Int -> Word16
 {-# INLINE [0] uncheckedShiftRL #-}
-#if __GLASGOW_HASKELL__
 -- GHC: use unboxing to get @uncheckedShiftRL@ inlined.
+#if __GLASGOW_HASKELL__ >= 902
+uncheckedShiftRL (W16# x) (I# i) = W16# (uncheckedShiftRLWord16# x i)
+#elif __GLASGOW_HASKELL__
 uncheckedShiftRL (W16# x) (I# i) = W16# (uncheckedShiftRL# x i)
 #else
 uncheckedShiftRL x i = shiftR x i

--- a/src/Data/Trie/Text/BitTwiddle.hs
+++ b/src/Data/Trie/Text/BitTwiddle.hs
@@ -28,7 +28,7 @@ module Data.Trie.Text.BitTwiddle
     , mask, shorter, branchMask
     ) where
 
-import Data.Trie.TextInternal (TextElem)
+import Data.Text.Internal.Word (TextElem)
 
 import Data.Bits
 
@@ -39,7 +39,7 @@ import GHC.Word (Word16(..))
 import GHC.Exts  (Int(..), uncheckedShiftRL# )
 import GHC.Word (Word16(..))
 #elif __GLASGOW_HASKELL__
-import GlaExts   ( Word8(..), Int(..), uncheckedShiftRL# )
+import GlaExts   (Int(..), uncheckedShiftRL# )
 import GHC.Word (Word16(..))
 #else
 import Data.Word (Word16(..))
@@ -52,7 +52,7 @@ type Prefix  = KeyElem
 type Mask    = KeyElem
 
 
-uncheckedShiftRL :: Word16 -> Int -> Word16
+uncheckedShiftRL :: TextElem -> Int -> TextElem
 {-# INLINE [0] uncheckedShiftRL #-}
 -- GHC: use unboxing to get @uncheckedShiftRL@ inlined.
 #if __GLASGOW_HASKELL__ >= 902
@@ -91,7 +91,7 @@ mask !i !m = maskW i m
 
 -- | Get mask by setting all bits higher than the smallest bit in
 -- @m@. Then apply that mask to @i@.
-maskW :: Word16 -> Word16 -> Prefix
+maskW :: TextElem -> TextElem -> Prefix
 {-# INLINE [0] maskW #-}
 maskW !i !m = i .&. (complement (m-1) `xor` m)
 -- TODO: try the alternatives mentioned in the Containers paper:
@@ -168,7 +168,7 @@ branchMask !p1 !p2
 --           -- !x -> case (x .|. uncheckedShiftRL x 16) of
 --            -- !x -> case (x .|. uncheckedShiftRL x 32) of   -- for 64 bit platforms
 --             !x -> (x `xor` uncheckedShiftRL x 1)
-highestBitMask :: Word16 -> Word16
+highestBitMask :: TextElem -> TextElem
 {-# INLINE [0] highestBitMask #-}
 highestBitMask !x0 =
   let !x1 = x0 .|. uncheckedShiftRL x0 1 in

--- a/src/Data/Trie/Text/Internal.hs
+++ b/src/Data/Trie/Text/Internal.hs
@@ -69,7 +69,7 @@ import Data.Trie.TextInternal
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as L
-import Data.Text.Internal.Word16 (head16, length16)
+import Data.Text.Internal.Word (head16, length16)
 
 import Data.Binary
 #if MIN_VERSION_base(4,9,0)

--- a/src/Data/Trie/Text/Internal.hs
+++ b/src/Data/Trie/Text/Internal.hs
@@ -69,7 +69,7 @@ import Data.Trie.TextInternal
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as L
-import Data.Text.Internal.Word (head16, length16)
+import Data.Text.Internal.Word (TextElem, head16, length16)
 
 import Data.Binary
 #if MIN_VERSION_base(4,9,0)

--- a/src/Data/Trie/Text/Internal.hs
+++ b/src/Data/Trie/Text/Internal.hs
@@ -69,7 +69,7 @@ import Data.Trie.TextInternal
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as L
-import Data.Text.Internal.Word (TextElem, head16, length16)
+import Data.Text.Internal.Word (TextElem, headElem, lengthElem)
 
 import Data.Binary
 #if MIN_VERSION_base(4,9,0)
@@ -446,7 +446,7 @@ getPrefix :: Trie a -> Prefix
 getPrefix (Branch p _ _ _) = p
 getPrefix (Arc k _ _)
   | T.null k = 0 -- for lack of a better value
-  | otherwise = head16 k
+  | otherwise = headElem k
 getPrefix Empty = error "getPrefix: no Prefix of Empty"
 
 
@@ -460,7 +460,7 @@ errorLogHead :: String -> Text -> TextElem
 {-# NOINLINE errorLogHead #-}
 errorLogHead fn q
     | T.null q  = error $ "Data.Trie.Internal." ++ fn ++": found null subquery"
-    | otherwise = head16 q
+    | otherwise = headElem q
 
 
 ------------------------------------------------------------
@@ -683,7 +683,7 @@ match_ = flip start
                   Just v  -> goJust n v n q t
           else Nothing
         Just (p,k',q') ->
-          let n' = n + length16 p
+          let n' = n + lengthElem p
           in n' `seq`
               if T.null k'
               then
@@ -727,7 +727,7 @@ match_ = flip start
                   Just v  -> goJust n  v  n q t
           else Just (n0,v0)
         Just (p,k',q') ->
-          let n' = n + length16 p
+          let n' = n + lengthElem p
           in n' `seq`
               if T.null k'
               then
@@ -787,7 +787,7 @@ matchFB_ = \t q cons nil -> matchFB_' cons q t nil
 
         go n q   (Arc k mv t) =
             let (p,k',q') = breakMaximalPrefix k q -- foobar
-                n'        = n + length16 p
+                n'        = n + lengthElem p
             in n' `seq`
                 if T.null k'
                 then

--- a/src/Data/Trie/TextInternal.hs
+++ b/src/Data/Trie/TextInternal.hs
@@ -12,18 +12,12 @@
 ------------------------------------------------------------
 
 module Data.Trie.TextInternal
-    ( Text, TextElem
+    ( Text
     , breakMaximalPrefix
     ) where
 
 import Data.Text (Text)
 import qualified Data.Text as T
-
-import Data.Word
-
-------------------------------------------------------------
--- | Associated type of 'Text'
-type TextElem = Word16
 
 -- | `T.commonPrefixes` unless `Nothing`,
 -- in which case @(`T.empty`, x, y)@ is returned

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - .
 extra-deps:
 - microbench-0.1
-resolver: lts-19.33
+resolver: lts-20.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,5 @@ flags: {}
 packages:
 - .
 extra-deps:
-- bytestring-trie-0.2.5.0
-resolver: lts-13.15
+- microbench-0.1
+resolver: lts-19.33

--- a/test.log
+++ b/test.log
@@ -68,7 +68,7 @@ prop_fromListWithConst_takes_first
 prop_fromListWithLConst_takes_first
 +++ OK, passed 500 tests.
 
-prop_length16_is_length_toList16
+prop_lengthElem_is_length_toListElem
 +++ OK, passed 500 tests.
 
 smallcheck @ () (Text):

--- a/test/Data/Trie/Text/Test.hs
+++ b/test/Data/Trie/Text/Test.hs
@@ -24,7 +24,7 @@ import qualified Data.Trie.Text             as Tr
 import qualified Data.Trie.Text.Convenience as TC
 import qualified Data.Text                  as T
 import qualified Data.Text.Lazy             as L
-import Data.Text.Internal.Word (toList16, length16)
+import Data.Text.Internal.Word (toListElem, lengthElem)
 
 import qualified Test.HUnit          as HU
 import qualified Test.QuickCheck     as QC
@@ -94,8 +94,8 @@ test  = do
     checkQuick 500  (prop_fromListWithLConst_takes_first :: [(Str, Int)] -> QC.Property)
     putStrLn ""
 
-    putStrLn "prop_length16_is_length_toList16"
-    checkQuick 500  (prop_length16_is_length_toList16 :: Str -> QC.Property)
+    putStrLn "prop_lengthElem_is_length_toListElem"
+    checkQuick 500  (prop_lengthElem_is_length_toListElem :: Str -> QC.Property)
     putStrLn ""
 
     putStrLn "smallcheck @ () (Text):" -- Beware the exponential!
@@ -419,13 +419,13 @@ x <== y =
 
 -- | Keys are ordered when converting to a list
 prop_toList :: Tr.Trie a -> QC.Property
-prop_toList t = ordered (toList16 . L.toStrict <$> Tr.keys t)
+prop_toList t = ordered (toListElem . L.toStrict <$> Tr.keys t)
     where ordered xs = QC.conjoin (zipWith (<==) xs (drop 1 xs))
 
 
 _takes_first :: (Eq c, Show c) => ([(L.Text, c)] -> Tr.Trie c) -> [(Str, c)] -> QC.Property
 _takes_first f assocs =
-    (Tr.toList . f) === (nubBy (apFst ((==) `on` (toList16 . L.toStrict))) . sortOn (toList16 . L.toStrict . fst))
+    (Tr.toList . f) === (nubBy (apFst ((==) `on` (toListElem . L.toStrict))) . sortOn (toListElem . L.toStrict . fst))
     $ map (first unStr) assocs
 
 
@@ -458,8 +458,8 @@ prop_fromListWithConst_takes_first = _takes_first (TC.fromListWith const . fmap 
 prop_fromListWithLConst_takes_first :: (Eq a, Show a) => [(Str, a)] -> QC.Property
 prop_fromListWithLConst_takes_first = _takes_first (TC.fromListWithL const . fmap (first L.toStrict))
 
-prop_length16_is_length_toList16 :: Str -> QC.Property
-prop_length16_is_length_toList16 = (length16 . L.toStrict . unStr) === (length . toList16 . L.toStrict . unStr)
+prop_lengthElem_is_length_toListElem :: Str -> QC.Property
+prop_lengthElem_is_length_toListElem = (lengthElem . L.toStrict . unStr) === (length . toListElem . L.toStrict . unStr)
 
 ----------------------------------------------------------------
 -- | Lift a function to apply to the first of pairs, retaining the second.

--- a/test/Data/Trie/Text/Test.hs
+++ b/test/Data/Trie/Text/Test.hs
@@ -24,7 +24,7 @@ import qualified Data.Trie.Text             as Tr
 import qualified Data.Trie.Text.Convenience as TC
 import qualified Data.Text                  as T
 import qualified Data.Text.Lazy             as L
-import Data.Text.Internal.Word16 (toList16, length16)
+import Data.Text.Internal.Word (toList16, length16)
 
 import qualified Test.HUnit          as HU
 import qualified Test.QuickCheck     as QC

--- a/text-trie.cabal
+++ b/text-trie.cabal
@@ -54,7 +54,8 @@ Extra-source-files:
 --     GHC ==8.0.1, GHC ==8.0.2,
 --     GHC ==8.2.1, GHC ==8.2.2,
 --     GHC ==8.4.1, GHC ==8.4.2, GHC ==8.4.3,
---     GHC ==8.6.1, GHC ==8.6.2
+--     GHC ==8.6.1, GHC ==8.6.2,
+--     GHC ==9.0.2
 
 Source-Repository head
     Type:     git
@@ -73,9 +74,9 @@ Library
     -- The lower bounds are more restrictive than necessary.
     -- But then, we don't maintain any CI tests for older
     -- versions, so these are the lowest bounds we've verified.
-    Build-Depends: base       >= 4.5   && < 4.13
-                 , text       >= 1.2.3 && < 1.2.4
-                 , binary     >= 0.5.1 && < 0.8.7
+    Build-Depends: base       >= 4.5   && < 4.16
+                 , text       >= 1.2.3 && < 1.2.6
+                 , binary     >= 0.5.1 && < 0.8.9
 
 ------------------------------------------------------------
 Test-Suite test-text-trie
@@ -90,15 +91,15 @@ Test-Suite test-text-trie
                   , FromListBench.Text.Encode
                   , TrieFile.Text
     build-depends: text-trie
-                 , base       >= 4.5   && < 4.13
+                 , base
                  , bytestring >= 0.9.2 && < 0.11
-                 , text       >= 1.2.3 && < 1.2.4
-                 , binary     >= 0.5.1 && < 0.8.7
+                 , text
+                 , binary
                  , QuickCheck
                  , HUnit
                  , smallcheck
                  , microbench
-                 , bytestring-trie >= 0.2.5 && < 0.2.6
+                 , bytestring-trie >= 0.2.5 && < 0.2.8
                  , silently >= 1.2.5 && < 1.2.6
 
 ------------------------------------------------------------

--- a/text-trie.cabal
+++ b/text-trie.cabal
@@ -69,7 +69,7 @@ Library
                    , Data.Trie.Text.Internal
                    , Data.Trie.Text.Convenience
                    , Data.Trie.TextInternal
-                   , Data.Text.Internal.Word16
+                   , Data.Text.Internal.Word
     Other-Modules:   Data.Trie.Text.BitTwiddle
                    , Data.Trie.Errors
     -- The lower bounds are more restrictive than necessary.

--- a/text-trie.cabal
+++ b/text-trie.cabal
@@ -57,6 +57,7 @@ Extra-source-files:
 --     GHC ==8.6.1, GHC ==8.6.2,
 --     GHC ==9.0.2,
 --     GHC ==9.2.5, GHC ==9.2.6
+--     GHC ==9.4.5
 
 Source-Repository head
     Type:     git
@@ -75,8 +76,8 @@ Library
     -- The lower bounds are more restrictive than necessary.
     -- But then, we don't maintain any CI tests for older
     -- versions, so these are the lowest bounds we've verified.
-    Build-Depends: base       >= 4.5   && < 4.17
-                 , text       >= 1.2.3 && < 1.2.6
+    Build-Depends: base       >= 4.5   && < 4.18
+                 , text       >= 1.2.3 && < 2.1
                  , binary     >= 0.5.1 && < 0.8.10
 
 ------------------------------------------------------------

--- a/text-trie.cabal
+++ b/text-trie.cabal
@@ -56,7 +56,7 @@ Extra-source-files:
 --     GHC ==8.4.1, GHC ==8.4.2, GHC ==8.4.3,
 --     GHC ==8.6.1, GHC ==8.6.2,
 --     GHC ==9.0.2,
---     GHC ==9.2.5
+--     GHC ==9.2.5, GHC ==9.2.6
 
 Source-Repository head
     Type:     git

--- a/text-trie.cabal
+++ b/text-trie.cabal
@@ -55,7 +55,8 @@ Extra-source-files:
 --     GHC ==8.2.1, GHC ==8.2.2,
 --     GHC ==8.4.1, GHC ==8.4.2, GHC ==8.4.3,
 --     GHC ==8.6.1, GHC ==8.6.2,
---     GHC ==9.0.2
+--     GHC ==9.0.2,
+--     GHC ==9.2.5
 
 Source-Repository head
     Type:     git
@@ -74,9 +75,9 @@ Library
     -- The lower bounds are more restrictive than necessary.
     -- But then, we don't maintain any CI tests for older
     -- versions, so these are the lowest bounds we've verified.
-    Build-Depends: base       >= 4.5   && < 4.16
+    Build-Depends: base       >= 4.5   && < 4.17
                  , text       >= 1.2.3 && < 1.2.6
-                 , binary     >= 0.5.1 && < 0.8.9
+                 , binary     >= 0.5.1 && < 0.8.10
 
 ------------------------------------------------------------
 Test-Suite test-text-trie
@@ -92,7 +93,7 @@ Test-Suite test-text-trie
                   , TrieFile.Text
     build-depends: text-trie
                  , base
-                 , bytestring >= 0.9.2 && < 0.11
+                 , bytestring >= 0.9.2 && < 0.12
                  , text
                  , binary
                  , QuickCheck


### PR DESCRIPTION
* In GHC 9.2 `uncheckedShiftRL` stopped compiling, but using the new `uncheckedShiftRLWord16` instead of `uncheckedShiftRLWord` fixes it
* In GHC 9.4 and `text-2` the representation of `Text` changed to be UTF-8 based rather than UTF-16, which required several changes under `CPP` branches.